### PR TITLE
Fix syntax error checks

### DIFF
--- a/test_data_reader.go
+++ b/test_data_reader.go
@@ -70,7 +70,7 @@ func (r *testDataReader) Next(t *testing.T) bool {
 		}
 
 		pos := fmt.Sprintf("%s:%d", r.sourceName, r.scanner.line)
-		cmd, args, err := ParseLine(pos, line)
+		cmd, args, err := ParseLine(line)
 		if err != nil {
 			t.Fatalf("%s: %v", pos, err)
 		}


### PR DESCRIPTION
My previous PR #2 introduced a bug (wasn't picked up in review).
Also wanted to enhance `ParseLine` as per Radu's suggestion in https://github.com/cockroachdb/datadriven/pull/2#issuecomment-554094575

- `ParseLine` now reports duplicate arguments on a single directive
  line. Also added tests to check this.
- there was a missing `err` return, this patch fixes it and adds a
  unit test.
- the location prefix would be reported two times, once because
  it was embedded in the error object and once because `t.Fatal`
  would prepend it again. This patch fixes it.
- the error message upon syntax errors was truncating the input
  line. This patch fixes that and also adds column information.
  Also checks this behavior via a unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/4)
<!-- Reviewable:end -->
