### PR TITLE
Avoid adding a newline if the output is empty otherwise

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -105,7 +105,7 @@ func runTestInternal(
 					}
 				}()
 				actual := f(d)
-				if !strings.HasSuffix(actual, "\n") {
+				if actual != "" && !strings.HasSuffix(actual, "\n") {
 					actual += "\n"
 				}
 				return actual


### PR DESCRIPTION
Found in https://github.com/cockroachdb/cockroach/pull/42573.

Many tests expect "no output". In these cases we want to avoid
adding a newline character because otherwise `-rewrite`
will change the expected output from a single delimiter:

```
dir
input
----
```

to a double double delimiter:

```
dir
input
----
----

----
----
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/5)
<!-- Reviewable:end -->
