### PR TITLE
Re-allow duplicate k=v pairs in a directive

### DIFF
--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -56,7 +56,7 @@ here: cannot parse directive at column 4: xx +++
 parse
 xx a=b a=c
 ----
-here: duplicate key in argument list: a=c
+"xx" [a=b a=c]
 
 parse
 xx a=b b=c c=(1,2,3)

--- a/line_parser.go
+++ b/line_parser.go
@@ -23,7 +23,6 @@ import (
 
 // ParseLine parses a line of datadriven input language and returns
 // the parsed command and CmdArgs.
-// Duplicate k=v arguments are rejected.
 func ParseLine(line string) (cmd string, cmdArgs []CmdArg, err error) {
 	fields, err := splitDirectives(line)
 	if err != nil {
@@ -34,17 +33,12 @@ func ParseLine(line string) (cmd string, cmdArgs []CmdArg, err error) {
 	}
 	cmd = fields[0]
 
-	seenArgs := make(map[string]struct{})
 	for _, arg := range fields[1:] {
 		key := arg
 		var vals []string
 		if pos := strings.IndexByte(key, '='); pos >= 0 {
 			key = arg[:pos]
 			val := arg[pos+1:]
-			if _, ok := seenArgs[key]; ok {
-				return "", nil, errors.Newf("duplicate key in argument list: %s", arg)
-			}
-			seenArgs[key] = struct{}{}
 
 			if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
 				vals = strings.Split(val[1:len(val)-1], ",")


### PR DESCRIPTION
This is used in CockroachDB in `pkg/sql/opt/memo/memo_test.go` test
`TestStats`, to specify multiple column stat groups side-by-side.

Found via https://github.com/cockroachdb/cockroach/pull/42573.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/6)
<!-- Reviewable:end -->
