### PR TITLE
Ensure the test callback sees the sub-test instance

### DIFF
--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -38,7 +38,7 @@ unknown command
 bar
 ----
 unknown command
-`, func(d *TestData) string {
+`, func(t *testing.T, d *TestData) string {
 		if d.Input != "sentence" {
 			return "unknown command"
 		}
@@ -62,12 +62,24 @@ parse
 xx a=b b=c c=(1,2,3)
 ----
 "xx" [a=b b=c c=(1, 2, 3)]
-`, func(d *TestData) string {
+`, func(t *testing.T, d *TestData) string {
 		cmd, args, err := ParseLine(d.Input)
 		if err != nil {
 			return errors.Wrap(err, "here").Error()
 		}
 		return fmt.Sprintf("%q %+v", cmd, args)
+	})
+}
+
+func TestSubTestSkip(t *testing.T) {
+	RunTestFromString(t, `
+error
+----
+`, func(t *testing.T, d *TestData) string {
+		// Verify that calling t.Skip() does not fail with an API error on
+		// testing.T.
+		t.Skip("woo")
+		return d.Expected
 	})
 }
 
@@ -82,7 +94,7 @@ Did the following: make sentence
 1 hungry monkey eats a 🍌
 while 12 other monkeys watch greedily,impatient
 true I'd say
-`, func(d *TestData) string {
+`, func(t *testing.T, d *TestData) string {
 		var one int
 		var twelve int
 		var banana string


### PR DESCRIPTION
I found this API usage error while attempting to run t.Fatal or t.Skip
inside a test directive: it's not possible to change the status of an
outer test instance while `datadriven.RunTest` has instantiated a
sub-test.

Symptom:
```
 test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

This patch fixes it by giving the sub-test instance to the
callback. All usages must be updated.

Needed for https://github.com/cockroachdb/cockroach/pull/42250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/7)
<!-- Reviewable:end -->
