### PR TITLE
Properly handle Skip in sub-test

### DIFF
--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -73,12 +73,22 @@ xx a=b b=c c=(1,2,3)
 
 func TestSubTestSkip(t *testing.T) {
 	RunTestFromString(t, `
+skip
+----
+
+# This error should never happen.
 error
 ----
 `, func(t *testing.T, d *TestData) string {
-		// Verify that calling t.Skip() does not fail with an API error on
-		// testing.T.
-		t.Skip("woo")
+		switch d.Cmd {
+		case "skip":
+			// Verify that calling t.Skip() does not fail with an API error on
+			// testing.T.
+			t.Skip("woo")
+		case "error":
+			// The skip should mask the error afterwards.
+			t.Error("never reached")
+		}
 		return d.Expected
 	})
 }


### PR DESCRIPTION
:man_facepalming:  I should really have tested this earlier.

Needed for https://github.com/cockroachdb/cockroach/pull/42152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/10)
<!-- Reviewable:end -->
