### PR TITLE
Implement subtest sections in input files

### DIFF
--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -71,7 +71,7 @@ xx a=b b=c c=(1,2,3)
 	})
 }
 
-func TestSubTestSkip(t *testing.T) {
+func TestSkip(t *testing.T) {
 	RunTestFromString(t, `
 skip
 ----
@@ -120,4 +120,31 @@ while %d other monkeys watch %s
 			d.Cmd, d.Input, one, banana, twelve, greedily, abc,
 		)
 	})
+}
+
+func TestSubTest(t *testing.T) {
+	foundData := false
+	Walk(t, "testdata", func(t *testing.T, path string) {
+		foundData = true
+		RunTest(t, path, func(t *testing.T, d *TestData) string {
+			switch d.Cmd {
+			case "hello":
+				return d.CmdArgs[0].Key + " was said"
+			case "skip":
+				// Verify that calling t.Skip() does not fail with an API error on
+				// testing.T.
+				t.Skip("woo")
+			case "error":
+				// The skip should mask the error afterwards.
+				t.Error("never reached")
+			default:
+				t.Fatalf("unknown directive: %s", d.Cmd)
+			}
+			return d.Expected
+		})
+	})
+
+	if !foundData {
+		t.Fatalf("no data file found")
+	}
 }

--- a/line_parser.go
+++ b/line_parser.go
@@ -54,7 +54,7 @@ func ParseLine(line string) (cmd string, cmdArgs []CmdArg, err error) {
 	return cmd, cmdArgs, nil
 }
 
-var splitDirectivesRE = regexp.MustCompile(`^ *[-a-zA-Z0-9_,\.]+(|=[-a-zA-Z0-9_@=+/,\.]*|=\([^)]*\))( |$)`)
+var splitDirectivesRE = regexp.MustCompile(`^ *[-a-zA-Z0-9/_,\.]+(|=[-a-zA-Z0-9_@=+/,\.]*|=\([^)]*\))( |$)`)
 
 // splits a directive line into tokens, where each token is
 // either:

--- a/testdata/subtest
+++ b/testdata/subtest
@@ -1,0 +1,19 @@
+hello world
+----
+world was said
+
+subtest hai
+
+hello universe
+----
+universe was said
+
+subtest hai/woo
+
+hello woo
+----
+woo was said
+
+subtest end hai/woo
+
+subtest end


### PR DESCRIPTION
Fixes #8.

This commit removes the one-subtest-per-directive logic and replaces
it by proper subtest support in the input DSL.

A sub-test begins with `subtest <name>` and ends with `subtest end [<name>]`.

- Sub-tests can be nested. However, the name of a nested sub-test must
  be prefixed by the name of the enclosing sub-test and a `/`.
- The name is optional after `end`; if present, it must match the
  corresponding start directive.
- Obviously "`end`" is not a valid name to start a subtest.

For example:

```
subtest foo

subtest foo/bar

subtest end foo/bar

subtest end
```

This will be used in https://github.com/cockroachdb/cockroach/pull/42250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/11)
<!-- Reviewable:end -->
