### PR TITLE
Enable running tests if the test inputs are read-only

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -86,7 +86,13 @@ var (
 // error by calling t.Error().
 func RunTest(t *testing.T, path string, f func(t *testing.T, d *TestData) string) {
 	t.Helper()
-	file, err := os.OpenFile(path, os.O_RDWR, 0644 /* irrelevant */)
+	mode := os.O_RDONLY
+	if *rewriteTestFiles {
+		// We only open read-write if rewriting, so as to enable running
+		// tests on read-only copies of the source tree.
+		mode = os.O_RDWR
+	}
+	file, err := os.OpenFile(path, mode, 0644 /* irrelevant */)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I was running some experiments using a build system that enforces "no
updating sources while the build is running" and the `datadriven`
tests started failing, even when `-rewrite` was not specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/15)
<!-- Reviewable:end -->
