### PR TITLE
Fix the generation of sub-test names

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -160,6 +160,11 @@ func runDirectiveOrSubTest(
 	}
 }
 
+// runSubTest runs a subtest up to and including the final `subtest
+// end`. The opening `subtest` directive has been consumed already.
+// The first parameter `subTestName` is the full path to the subtest,
+// including the parent subtest names as prefix. This is used to
+// validate the nesting and thus prevent mistakes.
 func runSubTest(
 	subTestName string, t *testing.T, r *testDataReader, f func(*testing.T, *TestData) string,
 ) {
@@ -173,8 +178,13 @@ func runSubTest(
 	// inside a subtest. See below for details.
 	seenSkip := false
 
+	// The name passed to t.Run is the last component in the subtest
+	// name, because all components before that are already prefixed by
+	// t.Run from the names of the parent sub-tests.
+	testingSubTestName := subTestName[strings.LastIndex(subTestName, "/")+1:]
+
 	// Begin the sub-test.
-	t.Run(subTestName, func(t *testing.T) {
+	t.Run(testingSubTestName, func(t *testing.T) {
 		defer func() {
 			// Skips are signalled using Goexit() so we must catch it /
 			// remember it here.


### PR DESCRIPTION
Found this while working on #14.

The DSL requires sub-test names to be prefixed by their
enclosing sub-test in the input, to clarify intent.

However the code was passing this string unmodified as first argument
to `t.Run`, which _also_ adds the parent name as prefix. The result
would be a doubly prefixed test name, for example `subtest hai/world`
would cause the sub-test to be named `hai/hai/world`, and
`hello/my/world` would become `hello/hello/my/hello/my/world`.

This patch fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/16)
<!-- Reviewable:end -->
