### PR TITLE
Warn when calling RunTest on directory

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -98,6 +98,12 @@ func RunTest(t *testing.T, path string, f func(t *testing.T, d *TestData) string
 	defer func() {
 		_ = file.Close()
 	}()
+	finfo, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	} else if finfo.IsDir() {
+		t.Fatalf("%s is a directly, not a file; consider using datadriven.Walk", path)
+	}
 
 	runTestInternal(t, path, file, f, *rewriteTestFiles)
 }


### PR DESCRIPTION
It's pretty easy to forget to use Walk and instead call RunTest directly
on a directory. This used to silently fail without running any tests. Now
it throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/18)
<!-- Reviewable:end -->
