### PR TITLE
Add program that clears results

### DIFF
--- a/datadriven-clear/main.go
+++ b/datadriven-clear/main.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <test-file>...", os.Args[0])
+		os.Exit(1)
+	}
+	for _, path := range os.Args[1:] {
+		err := datadriven.ClearResults(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Cleared %s.\n", path)
+	}
+}


### PR DESCRIPTION
When writing many new tests, it is sometimes useful to temporarily clear out all
results from a test file. This commit adds a `datadriven-clear` program that
does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/19)
<!-- Reviewable:end -->
