### PR TITLE
add rewrite tests and fix some issues

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -318,7 +318,9 @@ func runDirective(t *testing.T, r *testDataReader, f func(*testing.T, *TestData)
 			r.rewrite.WriteString(actual)
 			r.emit("----")
 			r.emit("----")
+			r.emit("")
 		} else {
+			// Here actual already ends in \n so emit adds a blank line.
 			r.emit(actual)
 		}
 	} else if d.Expected != actual {

--- a/test_data_reader.go
+++ b/test_data_reader.go
@@ -112,14 +112,14 @@ func (r *testDataReader) Next(t *testing.T) bool {
 		r.data.Input = strings.TrimSpace(buf.String())
 
 		if separator {
-			r.readExpected()
+			r.readExpected(t)
 		}
 		return true
 	}
 	return false
 }
 
-func (r *testDataReader) readExpected() {
+func (r *testDataReader) readExpected(t *testing.T) {
 	var buf bytes.Buffer
 	var line string
 	var allowBlankLines bool
@@ -140,6 +140,11 @@ func (r *testDataReader) readExpected() {
 				if r.scanner.Scan() {
 					line2 := r.scanner.Text()
 					if line2 == "----" {
+						// Read the following blank line (if we don't do this, we will emit
+						// an extra blank line when rewriting).
+						if r.scanner.Scan() && r.scanner.Text() != "" {
+							t.Fatal("non-blank line after end of double ---- separator section")
+						}
 						break
 					}
 

--- a/testdata/rewrite/basic-after
+++ b/testdata/rewrite/basic-after
@@ -1,0 +1,45 @@
+noop
+----
+
+noop
+----
+
+noop
+----
+
+
+noop
+some input
+----
+some input
+
+noop
+some input
+----
+some input
+
+duplicate
+some input
+----
+some input
+some input
+
+duplicate
+some input
+----
+some input
+some input
+
+
+duplicate-with-blank
+some input
+----
+----
+some input
+
+some input
+----
+----
+no-output
+some input
+----

--- a/testdata/rewrite/basic-after
+++ b/testdata/rewrite/basic-after
@@ -7,7 +7,6 @@ noop
 noop
 ----
 
-
 noop
 some input
 ----
@@ -29,7 +28,6 @@ some input
 ----
 some input
 some input
-
 
 duplicate-with-blank
 some input
@@ -40,6 +38,17 @@ some input
 some input
 ----
 ----
+
+duplicate-with-blank
+some input
+----
+----
+some input
+
+some input
+----
+----
+
 no-output
 some input
 ----

--- a/testdata/rewrite/basic-before
+++ b/testdata/rewrite/basic-before
@@ -1,0 +1,44 @@
+noop
+----
+
+noop
+----
+xxx
+
+noop
+----
+----
+xxx
+----
+----
+
+noop
+some input
+----
+
+noop
+some input
+----
+xxx
+
+duplicate
+some input
+----
+yyy
+
+duplicate
+some input
+----
+----
+yyy
+----
+----
+
+duplicate-with-blank
+some input
+----
+
+no-output
+some input
+----
+zzz

--- a/testdata/rewrite/basic-before
+++ b/testdata/rewrite/basic-before
@@ -38,6 +38,16 @@ duplicate-with-blank
 some input
 ----
 
+duplicate-with-blank
+some input
+----
+----
+some
+
+expected
+----
+----
+
 no-output
 some input
 ----

--- a/testdata/rewrite/eof-1-after
+++ b/testdata/rewrite/eof-1-after
@@ -1,0 +1,3 @@
+# Case where the last directive has blank output.
+noop
+----

--- a/testdata/rewrite/eof-1-before
+++ b/testdata/rewrite/eof-1-before
@@ -1,0 +1,3 @@
+# Case where the last directive has blank output.
+noop
+----

--- a/testdata/rewrite/eof-2-after
+++ b/testdata/rewrite/eof-2-after
@@ -1,0 +1,4 @@
+# Case where the last directive has blank output (but the double-separator
+# syntax is used in the test file).
+noop
+----

--- a/testdata/rewrite/eof-2-before
+++ b/testdata/rewrite/eof-2-before
@@ -1,0 +1,8 @@
+# Case where the last directive has blank output (but the double-separator
+# syntax is used in the test file).
+noop
+----
+----
+foo
+----
+----


### PR DESCRIPTION
#### add rewrite tests

This commit adds testing for -rewrite. The `testdata/rewrite` directory contains
pairs of files with before and after output. Note that the "after" output can
itself be regenerated using `-rewrite`.

#### fix rewrite issues for double-separator testcases

Fixing two problems related to rewriting testcases that use the double
separator:

 - we were adding an extra blank line when the original testfile uses the double
   separator;

 - we were not adding the expected blank line when the rewritten testfile uses
   the double separator.

Note that these two problems were canceling each other out when both the input
and the rewritten testcases use the double separator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/22)
<!-- Reviewable:end -->
