### PR TITLE
feature: print out unified diff for failed tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,4 +17,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/testdata/multiline
+++ b/testdata/multiline
@@ -1,0 +1,19 @@
+small
+----
+----
+just
+two lines of output
+----
+----
+
+large
+----
+----
+more
+than
+five
+lines
+of
+output
+----
+----


### PR DESCRIPTION
When there's a lot of output in a datadriven test, it can be challenging
to figure out what went wrong based on the output of the test if the
failure was just a subtle difference.

This commit introduces difflib and produces a unified diff when a test
fails that has more than 5 lines of output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/26)
<!-- Reviewable:end -->
