### PR TITLE
Add missing t.Helper()

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -188,6 +188,7 @@ func runDirectiveOrSubTest(
 	mandatorySubTestPrefix string,
 	f func(*testing.T, *TestData) string,
 ) {
+	t.Helper()
 	if subTestName, ok := isSubTestStart(t, r, mandatorySubTestPrefix); ok {
 		runSubTest(subTestName, t, r, f)
 	} else {


### PR DESCRIPTION
I noticed over in cockroachdb/cockroach that test failures were printed
as originating from `datadriven.go:194` as opposed to the actual test's
invocation of `datadriven.RunTest`. Inserting the missing `t.Helper()`
call seems to have fixed that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/28)
<!-- Reviewable:end -->
