### PR TITLE
show position in Fatal with long diffs

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -361,7 +361,7 @@ func runDirective(t *testing.T, r *testDataReader, f func(*testing.T, *TestData)
 				B:       actualLines,
 			})
 			if err == nil {
-				t.Fatalf("output didn't match expected:\n%s", diff)
+				t.Fatalf("\n%s: %s\noutput didn't match expected:\n%s", d.Pos, d.Input, diff)
 				return
 			}
 			t.Logf("Failed to produce diff %v", err)


### PR DESCRIPTION
In one case, the Fatalf call did not contain the current position and
input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/32)
<!-- Reviewable:end -->
