### PR TITLE
add Rewrite field to TestData

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -472,12 +472,16 @@ type TestData struct {
 
 	// Input is the text between the first directive line and the ---- separator.
 	Input string
+
 	// Expected is the value below the ---- separator. In most cases,
 	// tests need not check this, and instead return their own actual
 	// output.
 	// This field is provided so that a test can perform an early return
 	// with "return d.Expected" to signal that nothing has changed.
 	Expected string
+
+	// Rewrite is set if the test is being run with the -rewrite flag.
+	Rewrite bool
 }
 
 // HasArg checks whether the CmdArgs array contains an entry for the given key.

--- a/test_data_reader.go
+++ b/test_data_reader.go
@@ -114,6 +114,8 @@ func (r *testDataReader) Next(t *testing.T) bool {
 		if separator {
 			r.readExpected(t)
 		}
+
+		r.data.Rewrite = *rewriteTestFiles
 		return true
 	}
 	return false


### PR DESCRIPTION
Some tests do some shenanigans with the `Expected` field, like retrying.
Knowing that we are doing a `-rewrite` allows those tests to have more
reasonable behavior.