### PR TITLE
ignore test file extensions in Walk

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -422,10 +422,17 @@ func Walk(t *testing.T, path string, f func(t *testing.T, path string)) {
 			// Temp or hidden file, don't even try processing.
 			continue
 		}
-		t.Run(file.Name(), func(t *testing.T) {
+		t.Run(cutExt(file.Name()), func(t *testing.T) {
 			Walk(t, filepath.Join(path, file.Name()), f)
 		})
 	}
+}
+
+// cutExt returns the given file name with the extension removed, if there is
+// one.
+func cutExt(fileName string) string {
+	extStart := len(fileName) - len(filepath.Ext(fileName))
+	return fileName[:extStart]
 }
 
 func ClearResults(path string) error {

--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -150,6 +150,14 @@ func TestDirective(t *testing.T) {
 	})
 }
 
+func TestWalk(t *testing.T) {
+	Walk(t, "testdata/walk", func (t *testing.T, path string) {
+		RunTest(t, path, func (t *testing.T, d *TestData) string {
+			return fmt.Sprintf("test name: %s\n", t.Name())
+		})
+	})
+}
+
 func TestRewrite(t *testing.T) {
 	const testDir = "testdata/rewrite"
 	files, err := ioutil.ReadDir(testDir)

--- a/testdata/walk/ext.test
+++ b/testdata/walk/ext.test
@@ -1,0 +1,11 @@
+some-command
+----
+test name: TestWalk/ext
+
+subtest foo
+
+some-command
+----
+test name: TestWalk/ext/foo
+
+subtest end

--- a/testdata/walk/noext
+++ b/testdata/walk/noext
@@ -1,0 +1,11 @@
+some-command
+----
+test name: TestWalk/noext
+
+subtest foo
+
+some-command
+----
+test name: TestWalk/noext/foo
+
+subtest end


### PR DESCRIPTION
Subtests created by `Walk` now exclude extensions of test file names. For
example, if the test `TestFoo` uses `Walk` to test a file `foo.test`, the
subtest name will be `TestFoo/foo` rather than `TestFoo/foo.test`.

This change is motivated by https://github.com/cockroachdb/cockroach/pull/78048#issuecomment-1072739833.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/39)
<!-- Reviewable:end -->
