### PR TITLE
support parsing int64

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -579,6 +579,12 @@ func (arg CmdArg) scanErr(i int, dest interface{}) error {
 			return err
 		}
 		*dest = int(n) // assume 64bit ints
+	case *int64:
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		*dest = n
 	case *uint64:
 		n, err := strconv.ParseUint(val, 10, 64)
 		if err != nil {


### PR DESCRIPTION
int and uint64 were supported, but not int64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/40)
<!-- Reviewable:end -->
