### PR TITLE
change d argument to td in public APIs

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -112,16 +112,16 @@ func init() {
 //
 // It is also possible for a test to report an _unexpected_ test
 // error by calling t.Error().
-func RunTest(t *testing.T, path string, f func(t *testing.T, d *TestData) string) {
+func RunTest(t *testing.T, path string, f func(t *testing.T, td *TestData) string) {
 	t.Helper()
 
-	RunTestAny(t, path, func(t testing.TB, d *TestData) string {
-		return f(t.(*testing.T), d)
+	RunTestAny(t, path, func(t testing.TB, td *TestData) string {
+		return f(t.(*testing.T), td)
 	})
 }
 
 // RunTestAny is like RunTest but works over a testing.TB.
-func RunTestAny(t testing.TB, path string, f func(t testing.TB, d *TestData) string) {
+func RunTestAny(t testing.TB, path string, f func(t testing.TB, td *TestData) string) {
 	t.Helper()
 
 	mode := os.O_RDONLY
@@ -160,15 +160,15 @@ func RunTestAny(t testing.TB, path string, f func(t testing.TB, d *TestData) str
 
 // RunTestFromString is a version of RunTest which takes the contents of a test
 // directly.
-func RunTestFromString(t *testing.T, input string, f func(t *testing.T, d *TestData) string) {
+func RunTestFromString(t *testing.T, input string, f func(t *testing.T, td *TestData) string) {
 	t.Helper()
-	RunTestFromStringAny(t, input, func(t testing.TB, d *TestData) string {
-		return f(t.(*testing.T), d)
+	RunTestFromStringAny(t, input, func(t testing.TB, td *TestData) string {
+		return f(t.(*testing.T), td)
 	})
 }
 
 // RunTestFromStringAny is like RunTestFromString but works with a testing.TB.
-func RunTestFromStringAny(t testing.TB, input string, f func(t testing.TB, d *TestData) string) {
+func RunTestFromStringAny(t testing.TB, input string, f func(t testing.TB, td *TestData) string) {
 	t.Helper()
 	runTestInternal(t, "<string>" /* sourceName */, strings.NewReader(input), f, *rewriteTestFiles)
 }
@@ -177,7 +177,7 @@ func runTestInternal(
 	t testing.TB,
 	sourceName string,
 	reader io.Reader,
-	f func(t testing.TB, d *TestData) string,
+	f func(t testing.TB, td *TestData) string,
 	rewrite bool,
 ) (rewriteOutput []byte) {
 	t.Helper()
@@ -475,7 +475,7 @@ func ClearResults(path string) error {
 
 	runTestInternal(
 		&testing.T{}, path, file,
-		func(t testing.TB, d *TestData) string { return "" },
+		func(testing.TB, *TestData) string { return "" },
 		true, /* rewrite */
 	)
 


### PR DESCRIPTION
Cosmetic change to standardize on using `td` as the recommended name for the `*TestData` argument. `d` is too generic and can clash with common things (e.g.  the DB in Pebble). Probably half of the CRDB and Pebble code already uses `td`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/55)
<!-- Reviewable:end -->
