### PR TITLE
datadriven: log slow commands

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -337,6 +337,23 @@ func runDirective(t testing.TB, r *testDataReader, f func(testing.TB, *TestData)
 				panic(r)
 			}
 		}()
+
+		// Set up a goroutine to log periodically if the function is taking a long
+		// time. This is useful to pinpoint the cause of a test timeout.
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			startTime := time.Now()
+			for {
+				select {
+				case <-done:
+					return
+				case <-time.After(10 * time.Second):
+					t.Logf("%s: still running after %s\n", d.Pos, time.Since(startTime))
+				}
+			}
+		}()
+
 		actual := f(t, d)
 		if actual != "" && !strings.HasSuffix(actual, "\n") {
 			actual += "\n"


### PR DESCRIPTION
This change adds a `t.Log` every 10 seconds if the function that runs a directive takes a long time. This should show the cause of a test timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/57)
<!-- Reviewable:end -->
