### PR TITLE
fix 10s logging data race

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -347,7 +347,6 @@ func runDirective(t testing.TB, r *testDataReader, f func(testing.TB, *TestData)
 		// Set up a goroutine to log periodically if the function is taking a long
 		// time. This is useful to pinpoint the cause of a test timeout.
 		done := make(chan struct{})
-		defer close(done)
 		go func() {
 			startTime := time.Now()
 			for {
@@ -358,6 +357,11 @@ func runDirective(t testing.TB, r *testDataReader, f func(testing.TB, *TestData)
 					t.Logf("%s: still running after %s\n", d.Pos, time.Since(startTime))
 				}
 			}
+		}()
+		defer func() {
+			// Because the channel is unbuffered, we wait here until the goroutine is
+			// exiting.
+			done <- struct{}{}
 		}()
 
 		actual := f(t, d)


### PR DESCRIPTION
The goroutine that logs every 10 seconds can race with the function exiting, which can lead to a data race or even a panic because of t.Log used after the test exits.

The fix is to block until the goroutine is exiting, by writing to the unbuffered channel instead of closing it.

I reproduced and verified the fix, but it required temporary code changes and the test is too slow to check in.