### PR TITLE
use base 10 to parse integers

### DIFF
--- a/datadriven.go
+++ b/datadriven.go
@@ -879,14 +879,14 @@ func parseArgVal(s string, dest reflect.Value) error {
 		dest.SetBool(b)
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := strconv.ParseInt(s, 0, int(t.Bits()))
+		n, err := strconv.ParseInt(s, 10, int(t.Bits()))
 		if err != nil {
 			return fmt.Errorf("parse %q as %s: %w", s, t, err)
 		}
 		dest.SetInt(n)
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		n, err := strconv.ParseUint(s, 0, int(t.Bits()))
+		n, err := strconv.ParseUint(s, 10, int(t.Bits()))
 		if err != nil {
 			return fmt.Errorf("parse %q as %s: %w", s, t, err)
 		}

--- a/datadriven_test.go
+++ b/datadriven_test.go
@@ -326,7 +326,7 @@ func TestScanArgsSingle(t *testing.T) {
 ----
 []uint64{0x1, 0x2, 0x3, 0x4}
 
-[]int64 vals=(0xA, 0x10)
+[]int64 vals=(10, 000016)
 ----
 []int64{10, 16}
 


### PR DESCRIPTION
The new parsing code passes base 0 to strconv which causes it to interpret leading 0 as indicating an octal number. This is not what we want; in particular Pebble has a lot of tests which use file numbers with leading 0s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/datadriven/63)
<!-- Reviewable:end -->
